### PR TITLE
feat: add objective-based Pareto selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,6 +250,25 @@ python src/gepa/examples/terminal-bench/train_terminus.py --model_name=gpt-5-min
 
 GEPA optimizes text components of systems using an evolutionary search algorithm that uses LLM-based reflection for mutating candidates. Most importantly, GEPA leverages task-specific textual feedback (for example, compiler error messages, profiler performance reports, documentation, etc.) to guide the search process. For further details, refer to the paper: [GEPA: Reflective Prompt Evolution Can Outperform Reinforcement Learning](https://arxiv.org/abs/2507.19457).
 
+### Multi-Objective Selection
+
+GEPA can preserve trade-offs across multiple objectives by letting the metric return a dictionary of scores (see [paper](https://arxiv.org/abs/2507.19457) for discussion). For example:
+
+```python
+def metric(output):
+    return {"correct": score_correct(output), "fun": score_fun(output)}
+
+gepa_result = gepa.optimize(
+    seed_candidate=my_prog,
+    trainset=train_data,
+    valset=val_data,
+    objectives=["correct", "fun"],
+    selection_strategy="hybrid",
+)
+```
+
+GEPA normalizes per-objective scores (z-score by default) before computing Pareto fronts so objectives on different scales can be compared.
+
 ## Contributions
 
 We encourage the community and users to help us develop adapters to allow GEPA to be used for optimizing all kinds of systems leveraging textual components. Refer to [DSPy/GEPAAdapter](https://github.com/stanfordnlp/dspy/tree/main/dspy/teleprompt/gepa/gepa_utils.py) and [src/gepa/adapters/](src/gepa/adapters/) for example `GEPAAdapter` implementations. Please feel free to flag any problems faced as issues.

--- a/src/gepa/api.py
+++ b/src/gepa/api.py
@@ -27,6 +27,11 @@ def optimize(
     # Reflection-based configuration
     reflection_lm: LanguageModel | str | None = None,
     candidate_selection_strategy: str = "pareto",
+    objectives: list[str] | None = None,
+    selection_strategy: str = "auto",
+    normalize: str = "zscore",
+    global_bonus: int = 3,
+    instance_sample_size: int | None = None,
     skip_perfect_score=True,
     reflection_minibatch_size=3,
     perfect_score=1,
@@ -140,7 +145,18 @@ def optimize(
         valset = trainset
 
     rng = random.Random(seed)
-    candidate_selector = ParetoCandidateSelector(rng=rng) if candidate_selection_strategy == "pareto" else CurrentBestCandidateSelector()
+    candidate_selector = (
+        ParetoCandidateSelector(
+            rng=rng,
+            selection_strategy=selection_strategy,
+            objectives=objectives,
+            normalize=normalize,
+            global_bonus=global_bonus,
+            instance_sample_size=instance_sample_size,
+        )
+        if candidate_selection_strategy == "pareto"
+        else CurrentBestCandidateSelector()
+    )
     module_selector = RoundRobinReflectionComponentSelector()
     batch_sampler = EpochShuffledBatchSampler(minibatch_size=reflection_minibatch_size, rng=rng)
 

--- a/src/gepa/core/engine.py
+++ b/src/gepa/core/engine.py
@@ -83,7 +83,11 @@ class GEPAEngine(Generic[DataInst, Trajectory, RolloutOutput]):
         num_metric_calls_by_discovery = state.total_num_evals
 
         valset_outputs, valset_subscores = self._val_evaluator()(new_program)
-        valset_score = sum(valset_subscores) / len(valset_subscores)
+        scalar_subscores = [
+            sum(s.values()) / len(s) if isinstance(s, dict) else s
+            for s in valset_subscores
+        ]
+        valset_score = sum(scalar_subscores) / len(scalar_subscores)
 
         state.num_full_ds_evals += 1
         state.total_num_evals += len(valset_subscores)

--- a/src/gepa/core/result.py
+++ b/src/gepa/core/result.py
@@ -15,7 +15,7 @@ class GEPAResult(Generic[RolloutOutput]):
     - candidates: list of proposed candidates (component_name -> component_text)
     - parents: lineage info; for each candidate i, parents[i] is a list of parent indices or None
     - val_aggregate_scores: per-candidate aggregate score on the validation set (higher is better)
-    - val_subscores: per-candidate per-instance scores on the validation set (len == num_val_instances)
+    - val_subscores: per-candidate per-instance scores on the validation set (len == num_val_instances). Each score can be a scalar or a dict of objective scores.
     - per_val_instance_best_candidates: for each val instance t, a set of candidate indices achieving the current best score on t
     - discovery_eval_counts: number of metric calls accumulated up to the discovery of each candidate
 
@@ -43,7 +43,7 @@ class GEPAResult(Generic[RolloutOutput]):
     candidates: list[dict[str, str]]
     parents: list[list[int | None]]
     val_aggregate_scores: list[float]
-    val_subscores: list[list[float]]
+    val_subscores: list[list[Any]]
     per_val_instance_best_candidates: list[set[int]]
     discovery_eval_counts: list[int]
 

--- a/src/gepa/gepa_utils.py
+++ b/src/gepa/gepa_utils.py
@@ -73,9 +73,18 @@ def find_dominator_programs(pareto_front_programs, train_val_weighted_agg_scores
     uniq_progs = set(uniq_progs)
     return list(uniq_progs)
 
-def select_program_candidate_from_pareto_front(pareto_front_programs, train_val_weighted_agg_scores_for_all_programs, rng):
+def select_program_candidate_from_pareto_front(
+    pareto_front_programs,
+    train_val_weighted_agg_scores_for_all_programs,
+    rng,
+    instance_sample_size=None,
+):
     train_val_pareto_front_programs = pareto_front_programs
-    new_program_at_pareto_front_valset = remove_dominated_programs(train_val_pareto_front_programs, scores=train_val_weighted_agg_scores_for_all_programs)
+    if instance_sample_size is not None and len(train_val_pareto_front_programs) > instance_sample_size:
+        train_val_pareto_front_programs = rng.sample(train_val_pareto_front_programs, instance_sample_size)
+    new_program_at_pareto_front_valset = remove_dominated_programs(
+        train_val_pareto_front_programs, scores=train_val_weighted_agg_scores_for_all_programs
+    )
     program_frequency_in_validation_pareto_front = {}
     for testcase_pareto_front in new_program_at_pareto_front_valset:
         for prog_idx in testcase_pareto_front:
@@ -83,7 +92,11 @@ def select_program_candidate_from_pareto_front(pareto_front_programs, train_val_
                 program_frequency_in_validation_pareto_front[prog_idx] = 0
             program_frequency_in_validation_pareto_front[prog_idx] += 1
 
-    sampling_list = [prog_idx for prog_idx, freq in program_frequency_in_validation_pareto_front.items() for _ in range(freq)]
+    sampling_list = [
+        prog_idx
+        for prog_idx, freq in program_frequency_in_validation_pareto_front.items()
+        for _ in range(freq)
+    ]
     assert len(sampling_list) > 0
     curr_prog_id = rng.choice(sampling_list)
     return curr_prog_id

--- a/src/gepa/strategies/candidate_selector.py
+++ b/src/gepa/strategies/candidate_selector.py
@@ -1,7 +1,8 @@
 # Copyright (c) 2025 Lakshya A Agrawal and the GEPA contributors
 # https://github.com/gepa-ai/gepa
-
 import random
+from collections import defaultdict
+from typing import Iterable
 
 from gepa.core.state import GEPAState
 from gepa.gepa_utils import idxmax, select_program_candidate_from_pareto_front
@@ -9,19 +10,127 @@ from gepa.proposer.reflective_mutation.base import CandidateSelector
 
 
 class ParetoCandidateSelector(CandidateSelector):
-    def __init__(self, rng: random.Random | None):
-        if rng is None:
-            self.rng = random.Random(0)
-        else:
-            self.rng = rng
+    def __init__(
+        self,
+        rng: random.Random | None,
+        selection_strategy: str = "instance_pareto",
+        objectives: list[str] | None = None,
+        normalize: str = "zscore",
+        global_bonus: int = 3,
+        instance_sample_size: int | None = None,
+    ):
+        self.rng = rng or random.Random(0)
+        self.selection_strategy = selection_strategy
+        self.objectives = objectives
+        self.normalize = normalize
+        self.global_bonus = global_bonus
+        self.instance_sample_size = instance_sample_size
 
+    # --------- helpers ---------
+    def _resolve_strategy(self, state: GEPAState) -> str:
+        if self.selection_strategy == "auto":
+            return "objective_pareto" if getattr(state, "is_multi_objective", False) else "instance_pareto"
+        return self.selection_strategy
+
+    def _aggregate_objective_scores(self, state: GEPAState):
+        assert state.prog_candidate_val_subscores
+        # Determine objective names
+        if self.objectives is None:
+            first = state.prog_candidate_val_subscores[0][0]
+            if isinstance(first, dict):
+                objectives = list(first.keys())
+            else:
+                objectives = ["score"]
+        else:
+            objectives = self.objectives
+        vectors = []
+        for cand_scores in state.prog_candidate_val_subscores:
+            totals = defaultdict(float)
+            counts = defaultdict(int)
+            for score in cand_scores:
+                if isinstance(score, dict):
+                    for obj in objectives:
+                        if obj in score:
+                            totals[obj] += score[obj]
+                            counts[obj] += 1
+                else:
+                    totals[objectives[0]] += score
+                    counts[objectives[0]] += 1
+            means = {obj: (totals[obj] / counts[obj] if counts[obj] else 0.0) for obj in objectives}
+            vectors.append(means)
+        return objectives, vectors
+
+    def _normalize_vectors(self, objectives, vectors):
+        norm_vectors = [[0.0 for _ in objectives] for _ in vectors]
+        for j, obj in enumerate(objectives):
+            vals = [vec[obj] for vec in vectors]
+            if self.normalize == "minmax":
+                mn, mx = min(vals), max(vals)
+                rng = mx - mn if mx - mn != 0 else 1.0
+                for i, v in enumerate(vals):
+                    norm_vectors[i][j] = (v - mn) / rng
+            else:  # zscore
+                mean = sum(vals) / len(vals)
+                var = sum((v - mean) ** 2 for v in vals) / len(vals)
+                std = var ** 0.5 if var != 0 else 1.0
+                for i, v in enumerate(vals):
+                    norm_vectors[i][j] = (v - mean) / std
+        return norm_vectors
+
+    def _objective_front(self, state: GEPAState) -> set[int]:
+        objectives, vectors = self._aggregate_objective_scores(state)
+        norm_vectors = self._normalize_vectors(objectives, vectors)
+        m = len(objectives)
+        front = set(range(len(norm_vectors)))
+        for i, v in enumerate(norm_vectors):
+            for j, u in enumerate(norm_vectors):
+                if i == j:
+                    continue
+                if all(u[k] >= v[k] for k in range(m)) and any(u[k] > v[k] for k in range(m)):
+                    front.discard(i)
+                    break
+        return front
+
+    def _instance_weights(self, state: GEPAState):
+        fronts = state.program_at_pareto_front_valset
+        if self.instance_sample_size is not None and len(fronts) > self.instance_sample_size:
+            fronts = self.rng.sample(fronts, self.instance_sample_size)
+        freq: dict[int, int] = defaultdict(int)
+        for front in remove_empty(fronts):
+            for idx in front:
+                freq[idx] += 1
+        return freq
+
+    def _compute_weights(self, state: GEPAState, strategy: str):
+        if strategy == "instance_pareto":
+            return self._instance_weights(state)
+        if strategy == "objective_pareto":
+            front = self._objective_front(state)
+            return {idx: 1 for idx in front}
+        if strategy == "hybrid":
+            weights = self._instance_weights(state)
+            front = self._objective_front(state)
+            for idx in front:
+                weights[idx] = weights.get(idx, 0) + self.global_bonus
+            return weights
+        raise ValueError(f"Unknown selection strategy: {strategy}")
+
+    # --------- public API ---------
     def select_candidate_idx(self, state: GEPAState) -> int:
         assert len(state.per_program_tracked_scores) == len(state.program_candidates)
-        return select_program_candidate_from_pareto_front(
-            state.program_at_pareto_front_valset,
-            state.per_program_tracked_scores,
-            self.rng,
-        )
+        strategy = self._resolve_strategy(state)
+        if strategy == "instance_pareto":
+            return select_program_candidate_from_pareto_front(
+                state.program_at_pareto_front_valset,
+                state.per_program_tracked_scores,
+                self.rng,
+                instance_sample_size=self.instance_sample_size,
+            )
+        weights = self._compute_weights(state, strategy)
+        sampling_list = [idx for idx, w in weights.items() for _ in range(w)]
+        assert sampling_list, "No candidates to sample from"
+        return self.rng.choice(sampling_list)
+
 
 class CurrentBestCandidateSelector(CandidateSelector):
     def __init__(self):
@@ -30,3 +139,7 @@ class CurrentBestCandidateSelector(CandidateSelector):
     def select_candidate_idx(self, state: GEPAState) -> int:
         assert len(state.per_program_tracked_scores) == len(state.program_candidates)
         return idxmax(state.per_program_tracked_scores)
+
+
+def remove_empty(fronts: Iterable[set[int]]):
+    return [front for front in fronts if front]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,4 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath("src"))

--- a/tests/test_objective_pareto.py
+++ b/tests/test_objective_pareto.py
@@ -1,0 +1,68 @@
+import random
+from types import SimpleNamespace
+
+from gepa.strategies.candidate_selector import ParetoCandidateSelector
+
+
+class DummyState(SimpleNamespace):
+    pass
+
+
+def make_state(fronts, subscores, is_multi):
+    num_cands = len(subscores)
+    return DummyState(
+        program_at_pareto_front_valset=fronts,
+        per_program_tracked_scores=[0.0] * num_cands,
+        prog_candidate_val_subscores=subscores,
+        program_candidates=[{}] * num_cands,
+        is_multi_objective=is_multi,
+    )
+
+
+def test_hybrid_weights_nondomination():
+    fronts = [
+        {2},
+        {0, 1, 2},
+    ]
+    subscores = [
+        [
+            {"correct": 1, "fun": 0},
+            {"correct": 1, "fun": 0.2},
+        ],
+        [
+            {"correct": 0, "fun": 1},
+            {"correct": 0.2, "fun": 1},
+        ],
+        [
+            {"correct": 0.6, "fun": 0.6},
+            {"correct": 0.6, "fun": 0.6},
+        ],
+    ]
+    state = make_state(fronts, subscores, True)
+    selector = ParetoCandidateSelector(
+        rng=random.Random(0),
+        selection_strategy="hybrid",
+        global_bonus=3,
+    )
+    weights = selector._compute_weights(state, "hybrid")
+    assert weights == {0: 4, 1: 4, 2: 5}
+
+
+def test_scalar_fallback_auto():
+    fronts = [{0, 1}, {1}]
+    state = make_state(fronts, [[], []], False)
+    selector = ParetoCandidateSelector(rng=random.Random(0), selection_strategy="auto")
+    assert selector.select_candidate_idx(state) == 1
+
+
+def test_single_objective_equivalence():
+    fronts = [{0}, {0}]
+    subscores = [
+        [{"correct": 0.9}, {"correct": 0.8}],
+        [{"correct": 0.5}, {"correct": 0.4}],
+    ]
+    state = make_state(fronts, subscores, True)
+    selector = ParetoCandidateSelector(
+        rng=random.Random(0), selection_strategy="objective_pareto", objectives=["correct"]
+    )
+    assert selector.select_candidate_idx(state) == 0


### PR DESCRIPTION
## Summary
- support multi-objective evaluation with optional objective names and selection strategies
- add hybrid Pareto candidate selection over instances and objectives
- document and test objective-based Pareto selection

## Testing
- `pip install -e .` *(fails: Could not find a version that satisfies the requirement setuptools>=77.0.1)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a07c8a9274832da929ec7b93b7cceb