### PR TITLE
feat: add objective pareto selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,25 @@ print("GEPA Optimized Prompt:", gepa_result.best_candidate['system_prompt'])
 
 Here, we can see the optimized prompt that GEPA generates for AIME, which achieves **improves GPT-4.1 Mini's performance from 46.6% to 56.6%, an improvement of 10%** on AIME 2025. Note the details captured in the prompts in just 2 iterations of GEPA. GEPA can be thought of as precomputing some reasoning (during optimization) to come up with a good plan for future task instances.
 
+### Multi-Objective Selection
+
+GEPA can optimize across multiple objectives. Return a dict of scores from your metric and specify the objective names:
+
+```python
+def metric(output):
+    return {"correct": correctness(output), "fun": fun_score(output)}
+
+gepa.optimize(
+    seed_candidate=seed_prompt,
+    trainset=trainset,
+    valset=valset,
+    objectives=["correct", "fun"],
+    selection_strategy="hybrid",
+)
+```
+
+Scores are normalized per objective (z-score by default) before Pareto selection. The `hybrid` strategy maintains diversity over both instances and objectives.
+
 <table>
   <tr>
   <td colspan="2" align="center">Example GEPA Prompts</td>

--- a/src/gepa/core/result.py
+++ b/src/gepa/core/result.py
@@ -43,7 +43,7 @@ class GEPAResult(Generic[RolloutOutput]):
     candidates: list[dict[str, str]]
     parents: list[list[int | None]]
     val_aggregate_scores: list[float]
-    val_subscores: list[list[float]]
+    val_subscores: list[list[Any]]
     per_val_instance_best_candidates: list[set[int]]
     discovery_eval_counts: list[int]
 

--- a/src/gepa/gepa_utils.py
+++ b/src/gepa/gepa_utils.py
@@ -15,6 +15,111 @@ def idxmax(lst: list[float]) -> int:
     max_val = max(lst)
     return lst.index(max_val)
 
+
+def scalarize_score(score):
+    """Convert a possibly vector-valued score to a scalar."""
+    if isinstance(score, dict):
+        if len(score) == 0:
+            return 0.0
+        return sum(score.values()) / len(score)
+    return score
+
+
+def sum_scores(scores: list) -> float:
+    """Sum a list of scores that may be floats or dicts."""
+    return sum(scalarize_score(s) for s in scores)
+
+
+def normalize_objective_scores(
+    program_objective_scores: list[dict[str, float]],
+    method: str,
+    objectives: list[str],
+):
+    """Normalize per-objective scores across programs."""
+    normalized: list[dict[str, float]] = []
+    stats: dict[str, tuple[float, float]] = {}
+    for obj in objectives:
+        vals = [p.get(obj, 0.0) for p in program_objective_scores]
+        if method == "minmax":
+            min_v, max_v = min(vals), max(vals)
+            denom = max_v - min_v if max_v != min_v else 1.0
+            stats[obj] = (min_v, denom)
+        else:  # zscore
+            mean_v = sum(vals) / len(vals)
+            var = sum((v - mean_v) ** 2 for v in vals) / len(vals)
+            std = var ** 0.5 if var > 0 else 1.0
+            stats[obj] = (mean_v, std)
+    for p in program_objective_scores:
+        norm_p: dict[str, float] = {}
+        for obj in objectives:
+            offset, denom = stats[obj]
+            v = p.get(obj, 0.0)
+            if method == "minmax":
+                norm_p[obj] = (v - offset) / denom if denom != 0 else 0.0
+            else:
+                norm_p[obj] = (v - offset) / denom if denom != 0 else 0.0
+        normalized.append(norm_p)
+    return normalized
+
+
+def get_objective_front(
+    program_objective_scores: list[dict[str, float]],
+    method: str,
+    objectives: list[str],
+):
+    """Return set of program indices on the objective-based Pareto front."""
+    normalized = normalize_objective_scores(program_objective_scores, method, objectives)
+    nondominated: set[int] = set()
+    for i, p in enumerate(normalized):
+        dominated = False
+        for j, q in enumerate(normalized):
+            if i == j:
+                continue
+            if all(q[o] >= p[o] for o in objectives) and any(q[o] > p[o] for o in objectives):
+                dominated = True
+                break
+        if not dominated:
+            nondominated.add(i)
+    return nondominated
+
+
+def select_program_candidate_from_objective_pareto_front(
+    program_objective_scores: list[dict[str, float]],
+    rng,
+    method: str,
+    objectives: list[str],
+):
+    """Select a program from the objective-based Pareto front."""
+    front = list(get_objective_front(program_objective_scores, method, objectives))
+    assert len(front) > 0
+    return rng.choice(front)
+
+
+def select_program_candidate_from_hybrid_front(
+    instance_fronts: list[set[int]],
+    program_objective_scores: list[dict[str, float]],
+    rng,
+    method: str,
+    objectives: list[str],
+    global_bonus: int,
+    instance_sample_size: int | None = None,
+):
+    """Select a program balancing instance- and objective-level diversity."""
+    if instance_sample_size is not None:
+        sampled_fronts = rng.sample(instance_fronts, k=min(len(instance_fronts), instance_sample_size))
+    else:
+        sampled_fronts = instance_fronts
+    freq: dict[int, int] = {}
+    for front in sampled_fronts:
+        for idx in front:
+            freq[idx] = freq.get(idx, 0) + 1
+    objective_front = get_objective_front(program_objective_scores, method, objectives)
+    for idx in objective_front:
+        freq[idx] = freq.get(idx, 0) + global_bonus
+    sampling_list = [idx for idx, f in freq.items() for _ in range(f)]
+    assert len(sampling_list) > 0
+    return rng.choice(sampling_list)
+
 def is_dominated(y, programs, program_at_pareto_front_valset):
     y_fronts = [front for front in program_at_pareto_front_valset if y in front]
     for front in y_fronts:

--- a/src/gepa/proposer/base.py
+++ b/src/gepa/proposer/base.py
@@ -13,8 +13,8 @@ class CandidateProposal:
     parent_program_ids: list[int]
     # Optional mini-batch / subsample info
     subsample_indices: list[int] | None = None
-    subsample_scores_before: list[float] | None = None
-    subsample_scores_after: list[float] | None = None
+    subsample_scores_before: list[Any] | None = None
+    subsample_scores_after: list[Any] | None = None
     # Free-form metadata for logging/trace
     tag: str = ""
     metadata: dict[str, Any] = field(default_factory=dict)

--- a/src/gepa/proposer/reflective_mutation/base.py
+++ b/src/gepa/proposer/reflective_mutation/base.py
@@ -17,7 +17,7 @@ class ReflectionComponentSelector(Protocol):
         self,
         state: GEPAState,
         trajectories: list[Trajectory],
-        subsample_scores: list[float],
+        subsample_scores: list,
         candidate_idx: int,
         candidate: dict[str, str],
     ) -> list[str]:

--- a/src/gepa/strategies/candidate_selector.py
+++ b/src/gepa/strategies/candidate_selector.py
@@ -4,24 +4,68 @@
 import random
 
 from gepa.core.state import GEPAState
-from gepa.gepa_utils import idxmax, select_program_candidate_from_pareto_front
+from gepa.gepa_utils import (
+    idxmax,
+    select_program_candidate_from_pareto_front,
+    select_program_candidate_from_objective_pareto_front,
+    select_program_candidate_from_hybrid_front,
+)
 from gepa.proposer.reflective_mutation.base import CandidateSelector
 
 
 class ParetoCandidateSelector(CandidateSelector):
-    def __init__(self, rng: random.Random | None):
-        if rng is None:
-            self.rng = random.Random(0)
-        else:
-            self.rng = rng
+    def __init__(
+        self,
+        rng: random.Random | None,
+        selection_strategy: str = "auto",
+        objectives: list[str] | None = None,
+        normalize: str = "zscore",
+        global_bonus: int = 3,
+        instance_sample_size: int | None = None,
+    ):
+        self.rng = rng or random.Random(0)
+        self.selection_strategy = selection_strategy
+        self.objectives = objectives
+        self.normalize = normalize
+        self.global_bonus = global_bonus
+        self.instance_sample_size = instance_sample_size
 
     def select_candidate_idx(self, state: GEPAState) -> int:
+        strategy = self.selection_strategy
+        if strategy == "auto":
+            strategy = "objective_pareto" if state.is_multi_objective else "instance_pareto"
+
         assert len(state.per_program_tracked_scores) == len(state.program_candidates)
-        return select_program_candidate_from_pareto_front(
-            state.program_at_pareto_front_valset,
-            state.per_program_tracked_scores,
-            self.rng,
-        )
+
+        if strategy == "instance_pareto":
+            return select_program_candidate_from_pareto_front(
+                state.program_at_pareto_front_valset,
+                state.per_program_tracked_scores,
+                self.rng,
+            )
+        elif strategy == "objective_pareto":
+            assert state.program_objective_scores_val_set is not None
+            objs = self.objectives or state.objective_names or []
+            return select_program_candidate_from_objective_pareto_front(
+                state.program_objective_scores_val_set,
+                self.rng,
+                self.normalize,
+                objs,
+            )
+        elif strategy == "hybrid":
+            assert state.program_objective_scores_val_set is not None
+            objs = self.objectives or state.objective_names or []
+            return select_program_candidate_from_hybrid_front(
+                state.program_at_pareto_front_valset,
+                state.program_objective_scores_val_set,
+                self.rng,
+                self.normalize,
+                objs,
+                self.global_bonus,
+                self.instance_sample_size,
+            )
+        else:
+            raise ValueError(f"Unknown selection strategy: {strategy}")
 
 class CurrentBestCandidateSelector(CandidateSelector):
     def __init__(self):

--- a/src/gepa/strategies/component_selector.py
+++ b/src/gepa/strategies/component_selector.py
@@ -12,7 +12,7 @@ class RoundRobinReflectionComponentSelector(ReflectionComponentSelector):
         self,
         state: GEPAState,
         trajectories: list[Trajectory],
-        subsample_scores: list[float],
+        subsample_scores: list,
         candidate_idx: int,
         candidate: dict[str, str],
     ) -> list[str]:

--- a/tests/test_objective_pareto.py
+++ b/tests/test_objective_pareto.py
@@ -1,0 +1,107 @@
+import random
+from gepa.strategies.candidate_selector import ParetoCandidateSelector
+from gepa.core.state import GEPAState
+
+
+def make_state_dict(scores_per_candidate):
+    seed_candidate = {"c":"x"}
+    base_outputs = [None]*len(scores_per_candidate[0])
+    state = GEPAState(seed_candidate, (base_outputs, scores_per_candidate[0]))
+    for idx, sc in enumerate(scores_per_candidate[1:], start=1):
+        obj_scores = None
+        if state.is_multi_objective:
+            obj_scores = {k: sum(s[k] for s in sc)/len(sc) for k in sc[0].keys()}
+            val_score = sum(obj_scores.values())/len(obj_scores)
+        else:
+            val_score = sum(sc)/len(sc)
+        state.update_state_with_new_program(
+            parent_program_idx=[0],
+            new_program={"c":f"x{idx}"},
+            valset_score=val_score,
+            valset_outputs=base_outputs,
+            valset_subscores=sc,
+            run_dir=None,
+            num_metric_calls_by_discovery_of_new_program=0,
+            valset_objective_scores=obj_scores,
+        )
+    return state
+
+
+def test_nondomination_hybrid():
+    scores = [
+        [
+            {"correct":0.1,"fun":0.1},
+            {"correct":0.1,"fun":0.1},
+        ],
+        [
+            {"correct":1.0,"fun":0.2},
+            {"correct":0.6,"fun":0.1},
+        ],
+        [
+            {"correct":0.2,"fun":0.9},
+            {"correct":0.3,"fun":0.8},
+        ],
+    ]
+    state = make_state_dict(scores)
+    selector = ParetoCandidateSelector(
+        rng=random.Random(0),
+        selection_strategy="hybrid",
+        global_bonus=3,
+    )
+    counts = {0:0,1:0,2:0}
+    for _ in range(200):
+        idx = selector.select_candidate_idx(state)
+        counts[idx]+=1
+    assert counts[0]==0
+    assert counts[1]>0 and counts[2]>0
+
+
+def test_scalar_fallback_matches_previous():
+    scores = [
+        [0.5,0.3],
+        [0.6,0.2],
+        [0.4,0.7],
+    ]
+    state = make_state_dict(scores)
+    rng1 = random.Random(42)
+    selector = ParetoCandidateSelector(rng=rng1, selection_strategy="auto")
+    chosen = selector.select_candidate_idx(state)
+
+    rng2 = random.Random(42)
+    from gepa.gepa_utils import select_program_candidate_from_pareto_front
+    expected = select_program_candidate_from_pareto_front(
+        state.program_at_pareto_front_valset,
+        state.per_program_tracked_scores,
+        rng2,
+    )
+    assert chosen == expected
+
+
+def test_single_objective_equivalence():
+    scores = [
+        [
+            {"correct":0.5},
+            {"correct":0.5},
+        ],
+        [
+            {"correct":0.7},
+            {"correct":0.6},
+        ],
+        [
+            {"correct":0.4},
+            {"correct":0.8},
+        ],
+    ]
+    state = make_state_dict(scores)
+    rng1 = random.Random(1)
+    selector = ParetoCandidateSelector(rng=rng1, selection_strategy="objective_pareto")
+    chosen = selector.select_candidate_idx(state)
+
+    rng2 = random.Random(1)
+    from gepa.gepa_utils import select_program_candidate_from_pareto_front
+    expected = select_program_candidate_from_pareto_front(
+        state.program_at_pareto_front_valset,
+        state.per_program_tracked_scores,
+        rng2,
+    )
+    assert chosen == expected


### PR DESCRIPTION
## Summary
- extend `optimize` with multi-objective options and new selection strategies
- support objective-based and hybrid Pareto selection with normalization
- document multi-objective usage and add regression tests

## Testing
- `PYTHONPATH=src pytest tests/test_objective_pareto.py -q`
- `PYTHONPATH=src pytest -q`
- `pip install -e .` *(fails: Could not find a version that satisfies the requirement setuptools>=77.0.1)*


------
https://chatgpt.com/codex/tasks/task_e_68a07c8a9274832da929ec7b93b7cceb