### PR TITLE
feat: add multi-objective subscores support

### DIFF
--- a/src/gepa/core/adapter.py
+++ b/src/gepa/core/adapter.py
@@ -16,14 +16,19 @@ class EvaluationBatch(Generic[Trajectory, RolloutOutput]):
 
     - outputs: raw per-example outputs from upon executing the candidate. GEPA does not interpret these;
       they are forwarded to other parts of the user's code or logging as-is.
-    - scores: per-example numeric scores (floats). GEPA sums these for minibatch acceptance
-      and averages them over the full validation set for tracking/pareto fronts.
-    - trajectories: optional per-example traces used by make_reflective_dataset to build
-      a reflective dataset (See `GEPAAdapter.make_reflective_dataset`). If capture_traces=True is passed to `evaluate`, trajectories
-      should be provided and align one-to-one with `outputs` and `scores`.
+    - scores: per-example numeric scores (floats). GEPA sums these for minibatch
+      acceptance and averages them over the full validation set for tracking/pareto
+      fronts.
+    - subscores: optional per-example dictionaries capturing scores for multiple
+      objectives. When provided, GEPA can perform objective-level Pareto selection.
+    - trajectories: optional per-example traces used by make_reflective_dataset to
+      build a reflective dataset (See `GEPAAdapter.make_reflective_dataset`). If
+      capture_traces=True is passed to `evaluate`, trajectories should be provided
+      and align one-to-one with `outputs` and `scores`.
     """
     outputs: list[RolloutOutput]
     scores: list[float]
+    subscores: list[dict[str, float]] | None = None
     trajectories: list[Trajectory] | None = None
 
 class ProposalFn(Protocol):

--- a/src/gepa/core/result.py
+++ b/src/gepa/core/result.py
@@ -14,8 +14,11 @@ class GEPAResult(Generic[RolloutOutput]):
 
     - candidates: list of proposed candidates (component_name -> component_text)
     - parents: lineage info; for each candidate i, parents[i] is a list of parent indices or None
-    - val_aggregate_scores: per-candidate aggregate score on the validation set (higher is better)
-    - val_subscores: per-candidate per-instance scores on the validation set (len == num_val_instances)
+    - val_aggregate_scores: per-candidate aggregate scalar score on the validation set (higher is better)
+    - val_aggregate_subscores: per-candidate aggregate subscores on the validation set
+      keyed by objective name
+    - val_subscores: per-candidate per-instance subscores on the validation set
+      (len == num_val_instances)
     - per_val_instance_best_candidates: for each val instance t, a set of candidate indices achieving the current best score on t
     - discovery_eval_counts: number of metric calls accumulated up to the discovery of each candidate
 
@@ -43,7 +46,8 @@ class GEPAResult(Generic[RolloutOutput]):
     candidates: list[dict[str, str]]
     parents: list[list[int | None]]
     val_aggregate_scores: list[float]
-    val_subscores: list[list[float]]
+    val_aggregate_subscores: list[dict[str, float]] | None
+    val_subscores: list[list[dict[str, float]]]
     per_val_instance_best_candidates: list[set[int]]
     discovery_eval_counts: list[int]
 
@@ -84,6 +88,7 @@ class GEPAResult(Generic[RolloutOutput]):
             candidates=cands,
             parents=self.parents,
             val_aggregate_scores=self.val_aggregate_scores,
+            val_aggregate_subscores=self.val_aggregate_subscores,
             val_subscores=self.val_subscores,
             best_outputs_valset=self.best_outputs_valset,
             per_val_instance_best_candidates=[list(s) for s in self.per_val_instance_best_candidates],
@@ -104,6 +109,7 @@ class GEPAResult(Generic[RolloutOutput]):
             candidates=list(state.program_candidates),
             parents=list(state.parent_program_for_candidate),
             val_aggregate_scores=list(state.program_full_scores_val_set),
+            val_aggregate_subscores=list(getattr(state, "program_full_subscores_val_set", [])),
             best_outputs_valset=getattr(state, "best_outputs_valset", None),
             val_subscores=[list(s) for s in state.prog_candidate_val_subscores],
             per_val_instance_best_candidates=[set(s) for s in state.program_at_pareto_front_valset],


### PR DESCRIPTION
## Summary
- allow EvaluationBatch to carry per-objective subscores
- track and select candidates across instance, objective, or hybrid Pareto fronts
- expose multi-objective support in optimize API and merge proposer

## Testing
- `PYTHONPATH=src pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a1c6a2d010832dbd4b937818c2d6c7